### PR TITLE
use gzip instead of gunzip

### DIFF
--- a/hipp/dataquery/dataquery.py
+++ b/hipp/dataquery/dataquery.py
@@ -103,7 +103,7 @@ def EE_download_images_to_disk(
             max_workers=max_workers
         )
                                         
-        hipp.io.gunzip_dir(output_directory)
+        hipp.io.gzip_dir(output_directory)
         
         images_directory              = os.path.join(output_directory, images_directory_suffix)
         calibration_reports_directory = os.path.join(output_directory, calibration_reports_directory_suffix)

--- a/hipp/io/io.py
+++ b/hipp/io/io.py
@@ -1,6 +1,8 @@
 import glob
+import gzip
 import os
 import pathlib
+import shutil
 from subprocess import Popen, PIPE, STDOUT
 
 import hipp.io
@@ -25,6 +27,19 @@ def gunzip_dir(input_directory,
         files = sorted(glob.glob(os.path.join(input_directory,'*.gz')))
         for f in files:
             print(os.path.splitext(f)[0], 'already exists. -- skipped')
+            
+def gzip_dir(input_directory,
+               keep    = False):
+    print('gzipping files in', input_directory)
+    files = sorted(glob.glob(os.path.join(input_directory,'*.gz')))
+    for fn in files:
+        bn=os.path.basename(fn).split('.gz')[0]   
+        newpath=os.path.join(input_directory,bn)
+
+        with gzip.open(fn, 'r') as f_in, open(newpath, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+        if not keep:
+            os.remove(fn)
 
 def move_files(input_directory, 
                output_directory, 


### PR DESCRIPTION
**hipp/dataquery/dataquery.py**
- use `hipp.io.gzip()` instead of `hipp.io.gunzip()`

**hipp/io/io.py**
- add new `hipp.io.gzip()` function using python native `gzip`.

Could not modify [PR #8](https://github.com/friedrichknuth/hipp/pull/8) from remote fork:branch at `cmcneil-usgs:master` so making change via new PR.

resolves #7
